### PR TITLE
Add `encode_to_iodata` and `encode_to_iodata!` methods

### DIFF
--- a/lib/tiny.ex
+++ b/lib/tiny.ex
@@ -58,7 +58,7 @@ defmodule Tiny do
   end
 
   @doc """
-  Safely encodes a value to JSON as iodata.
+  Safely encodes a value to JSON as iodata. Same as passing `iodata: true` to `encode`.
   """
   @spec encode_to_iodata(json, Keyword.t) ::
     { :ok, iodata } |
@@ -67,7 +67,7 @@ defmodule Tiny do
     do: encode(val, [ iodata: true ] ++ opts)
 
   @doc """
-  Encodes a value to JSON as iodata.
+  Encodes a value to JSON as iodata. Same as passing `iodata: true` to `encode!`.
   """
   @spec encode_to_iodata!(json, Keyword.t) :: iodata | no_return
   def encode_to_iodata!(val, opts \\ []),

--- a/lib/tiny.ex
+++ b/lib/tiny.ex
@@ -45,7 +45,7 @@ defmodule Tiny do
   def encode(val, opts \\ []), do: wrap(&encode!/2, val, opts)
 
   @doc """
-  Encdoes a JSON compatible value to iodata or a binary.
+  Encodes a JSON compatible value to iodata or a binary.
 
   Rather than return Tuples, this function will raise `ArgumentError` on invalid
   inputs. No information is provided beyond the error, so log context as needed.
@@ -55,6 +55,24 @@ defmodule Tiny do
     result = do_encode(val)
     opts[:iodata] && result || :erlang.iolist_to_binary(result)
   rescue _ -> raise ArgumentError
+  end
+
+  @doc """
+  Safely encodes a value to JSON as iodata.
+  """
+  @spec encode_to_iodata(json, Keyword.t) ::
+    { :ok, iodata } |
+    { :error, atom }
+  def encode_to_iodata(val, opts \\ []) do
+    encode(val, [iodata: true] ++ opts)
+  end
+
+  @doc """
+  Encodes a value to JSON as iodata.
+  """
+  @spec encode_to_iodata!(json, Keyword.t) :: iodata | no_return
+  def encode_to_iodata!(val, opts \\ []) do
+    encode!(val, [iodata: true] ++ opts)
   end
 
   # Entry point of the main encoding path. We match on the value types before

--- a/lib/tiny.ex
+++ b/lib/tiny.ex
@@ -63,17 +63,15 @@ defmodule Tiny do
   @spec encode_to_iodata(json, Keyword.t) ::
     { :ok, iodata } |
     { :error, atom }
-  def encode_to_iodata(val, opts \\ []) do
-    encode(val, [iodata: true] ++ opts)
-  end
+  def encode_to_iodata(val, opts \\ []),
+    do: encode(val, [ iodata: true ] ++ opts)
 
   @doc """
   Encodes a value to JSON as iodata.
   """
   @spec encode_to_iodata!(json, Keyword.t) :: iodata | no_return
-  def encode_to_iodata!(val, opts \\ []) do
-    encode!(val, [iodata: true] ++ opts)
-  end
+  def encode_to_iodata!(val, opts \\ []),
+    do: encode!(val, [ iodata: true ] ++ opts)
 
   # Entry point of the main encoding path. We match on the value types before
   # handling them separately due to each being encoded differently. All calls

--- a/test/tiny_test.exs
+++ b/test/tiny_test.exs
@@ -30,10 +30,12 @@ defmodule TinyTest.Macro do
     result1 = Tiny.decode!(input)
     result2 = Tiny.encode!(result1)
     result3 = Tiny.decode!(result2)
+    result4 = Tiny.encode_to_iodata!(result1)
 
     assert(result1 === output)
     assert(result2 == encoded)
     assert(result3 == result1)
+    assert(:erlang.iolist_to_binary(result4) == encoded)
   end
 
 end


### PR DESCRIPTION
Poison has `encode_to_iodata` and `encode_to_iodata!` methods which are
used internally by `Phoenix.Controller` to encode response to JSON.

`Tiny` can become drop-in replacement for `Poison` if it'll have these methods.